### PR TITLE
Deglare

### DIFF
--- a/HDRutils/deglare.py
+++ b/HDRutils/deglare.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+import os.path as op
+import numpy as np
+from scipy.optimize import curve_fit
+from scipy.fftpack import fft2, ifft2, fftshift, ifftshift
+import matplotlib.pyplot as plt
+#import pyexr
+import image_io
+
+def create_rho_2D(im_size, nf_rows, nf_cols):
+    """
+    Create frequency coeffs.
+    Useful for constructing Fourier-domain filters based on OTF or CSF data.
+    """
+    half_size = np.floor(np.array(im_size) / 2).astype(int)
+    odd = np.mod(im_size, 2)
+    freq_step = [nf_rows, nf_cols] / half_size
+
+    if odd[1]:
+        xx = np.concatenate([
+            np.linspace(0, nf_cols, half_size[1] + 1),
+            np.linspace(-nf_cols, -freq_step[1], half_size[1])
+        ])
+    else:
+        xx = np.concatenate([
+            np.linspace(0, nf_cols - freq_step[1], half_size[1]),
+            np.linspace(-nf_cols, -freq_step[1], half_size[1])
+        ])
+
+    if odd[0]:
+        yy = np.concatenate([
+            np.linspace(0, nf_rows, half_size[0] + 1),
+            np.linspace(-nf_rows, -freq_step[0], half_size[0])
+        ])
+    else:
+        yy = np.concatenate([
+            np.linspace(0, nf_rows - freq_step[0], half_size[0]),
+            np.linspace(-nf_rows, -freq_step[0], half_size[0])
+        ])
+    rho_x, rho_y = np.meshgrid(xx, yy)
+    return rho_x, rho_y
+
+def gauss2(rho, a1, b1, c1, a2, b2, c2):
+    term1 = a1 * np.exp(-((rho - b1) / c1) ** 2)
+    term2 = a2 * np.exp(-((rho - b2) / c2) ** 2)
+    return term1 + term2
+
+def deglare(I, gParams):
+    I_deconv = np.zeros_like(I)
+    rho_x, rho_y = create_rho_2D(I.shape[:2], 0.5, 0.5)
+    rho_x, rho_y = fftshift(rho_x), fftshift(rho_y)
+    rho = np.sqrt(rho_x**2 + rho_y**2)
+    mtf_filter = gauss2(rho, *gParams)
+    for cc in range(1):
+        If = fftshift(fft2(I[:, :, cc]))
+        I_deconv[:, :, cc] = np.abs(ifft2(ifftshift(If / mtf_filter)))
+    return I_deconv
+
+def createFit(mtf_freq, mtf_amp):
+    #p0 = [1.0, 0.0, 0.0814, 0.6275, 0.138, 0.1001]
+    p0 = [0.5802, -0.01012, 0.1046, 0.4896, 0.3853, 0.9892]
+    low_bounds = [-np.inf, -np.inf, 0.0, -np.inf, -np.inf, 0.0]
+    up_bounds = [np.inf, np.inf, np.inf, np.inf, np.inf, np.inf]
+    params, _ = curve_fit(gauss2, xdata=mtf_freq, ydata=mtf_amp, p0=p0, bounds=(low_bounds, up_bounds), method='trf')
+    return params
+
+def plotFreqVsAmp(mtf_freq, mtf_amp, lowest_amp, gParams):
+        plt.figure('Deglaring GM Fit')
+        plt.scatter(mtf_freq, mtf_amp, label="mtf_amp vs. mtf_freq", c='k', marker='.')
+        plt.hlines(y=lowest_amp, xmin=0.0, xmax=0.5, linewidth=2, color='k', linestyle='--', alpha=0.5)
+        plt.plot(mtf_freq, gauss2(mtf_freq, *gParams), label="GM Fit", c='b', linewidth=2, alpha=0.5)
+        plt.ylim([0.0, 1.0])
+        plt.xlabel('mtf_freq')
+        plt.ylabel('mtf_amp')
+        plt.legend(loc='upper right')
+        plt.grid(True)
+
+# deglare an image with a single channel (using the luminance in the SFR)
+def deglare_channel(img, sfr, lowest_amp=0.5, freq_factor=1.0, amp_factor=1.0, plot=False):
+    if len(img.shape) == 2:
+        img = img.reshape(img.shape[0], img.shape[1], 1)
+
+    # Read data
+    T = np.genfromtxt(sfr, delimiter=',')
+    mtf_freq, mtf_amp = T[:, 0], T[:, 4]
+
+    # Multiplicative factors
+    mtf_freq *= freq_factor
+    mtf_amp  *= amp_factor
+
+    # Filter data
+    mtf_amp = mtf_amp[mtf_freq <= 0.5]
+    last_valid_index = np.where(mtf_freq <= 0.35)[0][-1]
+    mtf_amp[last_valid_index:] = mtf_amp[last_valid_index]
+    mtf_freq = mtf_freq[mtf_freq <= 0.5]
+    mtf_amp_clipped = np.clip(mtf_amp, lowest_amp, 1.0)
+    # Fit
+    gParams = createFit(mtf_freq, mtf_amp_clipped)
+    print("Fitted GM Parameters:", gParams)
+    if plot is True:
+        plotFreqVsAmp(mtf_freq, mtf_amp, lowest_amp, gParams)
+    img_deconv = deglare(img, gParams)
+    return img_deconv
+
+# deglare an image per channel (using the RGB curves of SFR instead of luminance)
+def deglareRGB_img(img, sfr, lowest_amp=0.5, freq_factor=1.0, amp_factor=1.0, plot=False):
+    # Read data
+    T = np.genfromtxt(sfr, delimiter=',')
+    gParams, img_deconv = [], []
+    for irgb in [0, 1, 2]:
+        mtf_freq, mtf_amp = T[:, 0], T[:, irgb+1]
+
+        # Multiplicative factors
+        mtf_freq *= freq_factor
+        mtf_amp  *= amp_factor
+
+        # Filter data
+        mtf_amp = mtf_amp[mtf_freq <= 0.5]
+        last_valid_index = np.where(mtf_freq <= 0.35)[0][-1]
+        mtf_amp[last_valid_index:] = mtf_amp[last_valid_index]
+        mtf_freq = mtf_freq[mtf_freq <= 0.5]
+        mtf_amp_clipped = np.clip(mtf_amp, lowest_amp, 1.0)
+        # Fit
+        gParams.append(createFit(mtf_freq, mtf_amp_clipped))
+        print("Fitted GM Parameters:", gParams[irgb])
+        if plot is True:
+            plotFreqVsAmp(mtf_freq, mtf_amp, lowest_amp, gParams[irgb])
+        img_deconv.append(deglare(img[:,:,irgb:irgb+1], gParams[irgb]))
+    img_deconv = np.moveaxis(np.squeeze(img_deconv), 0, -1)
+    return img_deconv
+

--- a/HDRutils/deglare.py
+++ b/HDRutils/deglare.py
@@ -70,7 +70,7 @@ def rggb2bayer(rggb): # input: array with 4x 2D arrays (rggb)
 	bayer[1::2, 1::2] = rggb[3]
 	return bayer # ouput: 2D array with bayer pattern [[r,g],[g,b]]
 
-# deglare an image with a single channel (using the luminance in the SFR).
+# deglare an image with a single channel (using the luminance in the MTF).
 def deglare_channel(img, gParams):
     if len(img.shape) == 2:
         img = img.reshape(img.shape[0], img.shape[1], 1)
@@ -78,9 +78,9 @@ def deglare_channel(img, gParams):
     return img_deconv[:,:,0]
 
 # deglare an image with a bayer pattern RGGB
-def deglare_bayer(bayer_img, sfr_json):
+def deglare_bayer(bayer_img, mtf_json):
     # Read GMM Fit params (Luminance)
-    with open(sfr_json) as f:
+    with open(mtf_json) as f:
         gParams_dict = json.load(f)
     gParams = gParams_dict["Y"]
 

--- a/HDRutils/merge.py
+++ b/HDRutils/merge.py
@@ -13,7 +13,7 @@ import numpy as np
 def merge(files, do_align=False, demosaic_first=True, normalize=False, color_space='sRGB',
 		  wb=None, saturation_percent=0.98, black_level=0, bayer_pattern='RGGB',
 		  exp=None, gain=None, aperture=None, estimate_exp=None, cam=None,
-		  outlier=None, demosaic='bilinear', clip_highlights=False, bits=None, ols=False, sfr_json=None):
+		  outlier=None, demosaic='bilinear', clip_highlights=False, bits=None, ols=False, mtf_json=None):
 	"""
 	Merge multiple SDR images into a single HDR image after demosacing. This is a wrapper
 	function that extracts metadata and calls the appropriate function.
@@ -71,7 +71,7 @@ def merge(files, do_align=False, demosaic_first=True, normalize=False, color_spa
 	if demosaic_first:
 		HDR, num_sat = imread_demosaic_merge(files, data, do_align, saturation_percent)
 	else:
-		HDR, num_sat = imread_merge_demosaic(files, data, do_align, bayer_pattern, demosaic, sfr_json=sfr_json)
+		HDR, num_sat = imread_merge_demosaic(files, data, do_align, bayer_pattern, demosaic, mtf_json=mtf_json)
 
 	if num_sat > 0:
 		logger.warning(f'{num_sat/(data["h"]*data["w"]):.3f}% of pixels (n={num_sat}) are ' \
@@ -147,7 +147,7 @@ def imread_demosaic_merge(files, metadata, do_align, sat_percent):
 	return HDR, num_sat
 
 
-def imread_merge_demosaic(files, metadata, do_align, pattern, demosaic, sfr_json=None):
+def imread_merge_demosaic(files, metadata, do_align, pattern, demosaic, mtf_json=None):
 	"""
 	Merge RAW images before demosaicing. This function merges in an online
 	way and can handle a large number of inputs with little memory.
@@ -235,9 +235,9 @@ def imread_merge_demosaic(files, metadata, do_align, pattern, demosaic, sfr_json
 	HDR_bayer = num / denom
 
 	# Deglaring (MTF Inversion)
-	if sfr_json is not None:
+	if mtf_json is not None:
 		logger.info("Applying deglaring")
-		HDR_bayer = deglare_bayer(HDR_bayer, sfr_json=sfr_json)
+		HDR_bayer = deglare_bayer(HDR_bayer, mtf_json=mtf_json)
 
 	# Libraw does not support 32-bit values. Use colour-demosaicing instead:
 	# https://colour-demosaicing.readthedocs.io/en/latest/manual.html

--- a/HDRutils/merge.py
+++ b/HDRutils/merge.py
@@ -13,7 +13,8 @@ import numpy as np
 def merge(files, do_align=False, demosaic_first=True, normalize=False, color_space='sRGB',
 		  wb=None, saturation_percent=0.98, black_level=0, bayer_pattern='RGGB',
 		  exp=None, gain=None, aperture=None, estimate_exp=None, cam=None,
-		  outlier=None, demosaic='bilinear', clip_highlights=False, bits=None, ols=False, mtf_json=None):
+		  outlier=None, demosaic='bilinear', clip_highlights=False, bits=None, solver='wls',
+		  return_exif_exp=False, mtf_json=None):
 	"""
 	Merge multiple SDR images into a single HDR image after demosacing. This is a wrapper
 	function that extracts metadata and calls the appropriate function.
@@ -36,10 +37,13 @@ def merge(files, do_align=False, demosaic_first=True, normalize=False, color_spa
 	:demosaic: Demosaicing algorithm if "demosaic_first" is False. Pick 1 of ['bilinear', 'malvar', 'menon']
 	:clip_highlights: Clip pixels that are saturated in the lowest exposure
 	:bits: Number of quantization bits for simulated data
+	:solver: How to solve the linear system for exposure estimation
+	:mtf_json: JSON file with fitted MTF curves for deglaring.
 
 	:return: Merged FP32 HDR image, mask of unsaturated pixels
 	"""
 	data = get_metadata(files, exp, gain, aperture, color_space, saturation_percent, black_level, bits)
+	exif = data['exp'].copy()
 	if estimate_exp:
 		# TODO: Handle imamge stacks with varying gain and aperture
 		assert len(set(data['gain'])) == 1 and len(set(data['aperture'])) == 1
@@ -57,16 +61,17 @@ def merge(files, do_align=False, demosaic_first=True, normalize=False, color_spa
 			black_frame = np.ones_like(Y[0]) * data['black_level'][:3][None,None]
 		for i in range(data['N']):
 			# Skip images where > 95% of the pixels are overexposed or underexposed
-			noise_floor = data['saturation_point']/1000
+			noise_floor = max(data['saturation_point']/1000, np.abs((Y[0] - black_frame).min()))
 			if (Y[i] >= data['saturation_point']).sum() > 0.95*Y[i].size:
 				logger.warning(f'Skipping exposure estimation for file {files[i]} due to saturation')
 				estimate[i] = False
 			elif (Y[i] - black_frame <= noise_floor).sum() > 0.95*Y[i].size:
 				logger.warning(f'Skipping exposure estimation for file {files[i]} due to noise')
 				estimate[i] = False
-		data['exp'][estimate] = estimate_exposures(Y[estimate], data['exp'][estimate], data,
+		if estimate.sum() > 2:
+			data['exp'][estimate] = estimate_exposures(Y[estimate], data['exp'][estimate], data,
 												   estimate_exp, cam=cam, outlier=outlier,
-												   noise_floor=noise_floor, ols=ols)
+												   noise_floor=noise_floor, solver=solver)
 
 	if demosaic_first:
 		HDR, num_sat = imread_demosaic_merge(files, data, do_align, saturation_percent)
@@ -95,7 +100,11 @@ def merge(files, do_align=False, demosaic_first=True, normalize=False, color_spa
 	if clip_highlights:
 		logger.info(f'Clipping all saturated highlights to {HDR.max()}')
 		HDR[np.logical_not(unsaturated)] = HDR.max()
-	return HDR.astype(np.float32), unsaturated
+
+	if return_exif_exp:
+		return HDR.astype(np.float32), exif, data['exp']
+	else:
+		return HDR.astype(np.float32), unsaturated
 
 
 def imread_demosaic_merge(files, metadata, do_align, sat_percent):

--- a/README.md
+++ b/README.md
@@ -101,6 +101,20 @@ Exposure metadata from EXIF may be inaccurate and it may be benificial to estima
 
 This feauture is currently disabled, and EXIF values are used by default. To enable exposure estimation, run `HDRutils.merge(..., estimate_exp='mst')`.
 
+### Deglaring via MTF inversion
+Camera lens aberrations produce attenuations of spatial frequencies, which have a strong effect on the image sharpness.
+The Modulation Transfer Function (MTF) models the response of the camera as a function of the spatial frequency (in cycles/pixel),
+and can be used to increase the sharpness of images captured by the camera, by applying a Fourier space deconvolution
+[[Chen et al. 2023]](https://stereohdrgloss.mpi-inf.mpg.de/#:~:text=A%20faithful%20reproduction%20of%20gloss,a%20real%2Dworld%20reference%20object.).
+
+The procedure to compute a camera's MTF is described in detail [here](https://github.com/gfxdisp/lf_capture/tree/master/deglare).
+The output of this procedure is a JSON file describing the MTF via the coefficients of a Gaussian Mixture Model. This file can be used
+in HDRutils to perform the deglaring, after merging RAW files and before demosaicing. To perform merge+deglare+demosaic on a set of RAW images,
+run the merge function with the following arguments:
+```
+HDRutils.merge(..., color_space="raw", demosaic_first=False, mtf_json=<mtf.json>)
+```
+
 ## Noise simulation
 Generating realistic camera noise using calibrated parameters of real-world cameras is described [here](HDRutils/noise_modeling/).
 


### PR DESCRIPTION
Implemented deglaring after merging but before demosaicing.
The new implementation is in a branch "Deglare".
Most of the implementation is in the new file deglare.py.
There are also minor modifications of merge.py.
I added a single additional argument to merge, named "mtf_json".
By default this is None, so no deglaring is applied. If an <mtf.json> file is specified, the MTF curve described in that file is used to perform the deglaring.
The procedure and code to generate these json files is explained in the lf_capture/deglare README:
https://github.com/gfxdisp/lf_capture/tree/master/deglare

Merging branch Deglare with main:
If desired, merging with main should be possible directly. Differences in merge.py are minimal, and the default functionality was not altered.